### PR TITLE
Fix command usage message with dynamic syntax replacement

### DIFF
--- a/src/main/java/eu/athelion/dailyrewards/commandmanager/subcommand/ToggleCommand.java
+++ b/src/main/java/eu/athelion/dailyrewards/commandmanager/subcommand/ToggleCommand.java
@@ -52,7 +52,7 @@ public class ToggleCommand implements SubCommand {
         }
 
         if (args.length < 1) {
-            sender.sendMessage(Lang.COMMAND_USAGE.asColoredString());
+            sender.sendMessage(Lang.COMMAND_USAGE.asColoredString().replace("%usage%", getSyntax()));
             return;
         }
 


### PR DESCRIPTION
When you don't add the required arguments for the command **'/rw toggle'** it does not replace the argument %usage% as it does with other arguments. 

This pr should fix it. I can't compile the plugin because an error on the ItemsAdder API dependency so I didn't test it.

![image](https://github.com/user-attachments/assets/378c34af-61be-4cd4-b15c-18483b53fa22)